### PR TITLE
Portfolio preserve data local storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,11 +299,14 @@
                 ></textarea>
               </p>
               <p class="alert alert-danger d-none" role="alert" id="alert"></p>
-              <p>
+              <div
+                class="d-flex flex-column justify-content-center align-items-center"
+              >
                 <button id="btn-contact-form" type="submit">
                   Get in touch
                 </button>
-              </p>
+                <button id="btn-reset" class="mt-5">Reset form</button>
+              </div>
             </fieldset>
           </form>
         </div>

--- a/index.html
+++ b/index.html
@@ -315,5 +315,6 @@
     </section>
     <script src="./javascript/app.js"></script>
     <script src="./javascript/validation.js"></script>
+    <script src="./javascript/localStorage.js"></script>
   </body>
 </html>

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -1,0 +1,14 @@
+// get form elements
+// check local storage available
+// - if available : create local storage object
+// - if not: null
+// create a single object for the data
+// listen to change on input fields
+// stringify that data
+// set the object to local
+// on loads of page
+// - if available:
+// - if local storage has data: put data into fiels
+// if not: nothing
+// - if not: null
+//! create a reset button that reset the input fields and delete data in local storage

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -92,3 +92,11 @@ function retrieveData() {
 window.onload = () => {
   retrieveData();
 };
+
+const btnReset = document.getElementById('btn-reset');
+
+btnReset.addEventListener('click', (event) => {
+  event.preventDefault();
+  contactForm.reset();
+  availableStorage.clear();
+});

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -6,11 +6,10 @@
 // listen to change on input fields ✅
 // stringify that data ✅
 // set the object to local ✅
-// on loads of page
-// - if available:
-// - if local storage has data: put data into fiels
-// if not: nothing
-// - if not: null
+// on loads of page ✅
+// - if available: 
+// - if local storage has data: put data into fiels ✅
+// if not: nothing ✅
 //! create a reset button that reset the input fields and delete data in local storage
 
 const contactForm = document.getElementById('contact-form');
@@ -75,7 +74,18 @@ message.addEventListener('change', () => {
   storeData(formData);
 });
 
+function retrieveData() {
+  const data = availableStorage.getItem('contactFormData');
+  const parseData = JSON.parse(data)
+  if(data?.length > 0) {
+    console.log(parseData)
+    const {name: nameInput, email: emailInput, message: messageInput} = parseData
+    name.value = nameInput ? nameInput : ''
+    email.value = emailInput ? emailInput : ''
+    message.value = messageInput ? messageInput : ''
+  }
+}
+
 window.onload = () => {
-  const retrievedData = availableStorage.getItem('contactFormData');
-  console.log(retrievedData);
+  retrieveData()
 };

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -1,7 +1,7 @@
-// get form elements
-// check local storage available
-// - if available : create local storage object
-// - if not: null
+// get form elements ✅
+// check local storage available ✅
+// - if available : create local storage object ✅
+// - if not: null ✅
 // create a single object for the data
 // listen to change on input fields
 // stringify that data
@@ -12,3 +12,42 @@
 // if not: nothing
 // - if not: null
 //! create a reset button that reset the input fields and delete data in local storage
+
+const contactForm = document.getElementById('contact-form');
+
+function storageAvailable(type) {
+  let storage;
+  try {
+    storage = window[type];
+    const x = '__storage_test__';
+    storage.setItem(x, x);
+    storage.removeItem(x);
+    return true;
+  } catch (e) {
+    return (
+      e instanceof DOMException &&
+      // everything except Firefox
+      (e.code === 22 ||
+        // Firefox
+        e.code === 1014 ||
+        // test name field too, because code might not be present
+        // everything except Firefox
+        e.name === 'QuotaExceededError' ||
+        // Firefox
+        e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+      // acknowledge QuotaExceededError only if there's something already stored
+      storage &&
+      storage.length !== 0
+    );
+  }
+}
+
+let availableStorage;
+
+if (storageAvailable('localStorage')) {
+  // Yippee! We can use localStorage awesomeness
+  availableStorage = window.localStorage;
+} else {
+  // Too bad, no localStorage for us
+  return;
+}

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -53,20 +53,29 @@ if (storageAvailable('localStorage')) {
   availableStorage = null;
 }
 
-let formData = {};
+const formData = {};
+
+function storeData(formData) {
+  const jsonData = JSON.stringify(formData);
+  availableStorage.setItem('contactFormData', jsonData);
+}
 
 name.addEventListener('change', () => {
   formData.name = name.value;
+  storeData(formData);
 });
 
 emailInput.addEventListener('change', () => {
   formData.email = emailInput.value;
+  storeData(formData);
 });
 
 message.addEventListener('change', () => {
   formData.message = message.value;
+  storeData(formData);
 });
 
-let jsonData = JSON.stringify(formData);
-
-availableStorage.setItem('contactFormData', jsonData)
+window.onload = () => {
+  const retrievedData = availableStorage.getItem('contactFormData');
+  console.log(retrievedData);
+};

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -7,13 +7,17 @@
 // stringify that data ✅
 // set the object to local ✅
 // on loads of page ✅
-// - if available: 
+// - if available:
 // - if local storage has data: put data into fiels ✅
 // if not: nothing ✅
 //! create a reset button that reset the input fields and delete data in local storage
 
 const contactForm = document.getElementById('contact-form');
-const { name, email: emailInput, message } = contactForm.elements;
+const {
+  name: nameInput,
+  email: emailInput,
+  message: messageInput,
+} = contactForm.elements;
 
 function storageAvailable(type) {
   let storage;
@@ -54,38 +58,37 @@ if (storageAvailable('localStorage')) {
 
 const formData = {};
 
-function storeData(formData) {
+function storeData() {
+  formData.name = nameInput.value;
+  formData.email = emailInput.value;
+  formData.message = messageInput.value;
   const jsonData = JSON.stringify(formData);
   availableStorage.setItem('contactFormData', jsonData);
 }
 
-name.addEventListener('change', () => {
-  formData.name = name.value;
-  storeData(formData);
+nameInput.addEventListener('change', () => {
+  storeData();
 });
 
 emailInput.addEventListener('change', () => {
-  formData.email = emailInput.value;
-  storeData(formData);
+  storeData();
 });
 
-message.addEventListener('change', () => {
-  formData.message = message.value;
-  storeData(formData);
+messageInput.addEventListener('change', () => {
+  storeData();
 });
 
 function retrieveData() {
   const data = availableStorage.getItem('contactFormData');
-  const parseData = JSON.parse(data)
-  if(data?.length > 0) {
-    console.log(parseData)
-    const {name: nameInput, email: emailInput, message: messageInput} = parseData
-    name.value = nameInput ? nameInput : ''
-    email.value = emailInput ? emailInput : ''
-    message.value = messageInput ? messageInput : ''
+  const parseData = JSON.parse(data);
+  if (data?.length > 0) {
+    const { name, email, message } = parseData;
+    nameInput.value = name || '';
+    emailInput.value = email || '';
+    messageInput.value = message || '';
   }
 }
 
 window.onload = () => {
-  retrieveData()
+  retrieveData();
 };

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -4,7 +4,7 @@
 // - if not: null ✅
 // create a single object for the data ✅
 // listen to change on input fields ✅
-// stringify that data
+// stringify that data ✅
 // set the object to local
 // on loads of page
 // - if available:
@@ -14,7 +14,7 @@
 //! create a reset button that reset the input fields and delete data in local storage
 
 const contactForm = document.getElementById('contact-form');
-const {name, email: emailInput, message} = contactForm.elements
+const { name, email: emailInput, message } = contactForm.elements;
 
 function storageAvailable(type) {
   let storage;
@@ -50,17 +50,21 @@ if (storageAvailable('localStorage')) {
   availableStorage = window.localStorage;
 } else {
   // Too bad, no localStorage for us
- availableStorage = null;
+  availableStorage = null;
 }
 
-let formData;
+let formData = {};
 
-name.addEventListener('change', (event) => {
-  console.log(event)
-})
-emailInput.addEventListener('change', (event) => {
-  console.log(event)
-})
-message.addEventListener('change', (event) => {
-  console.log(event)
-})
+name.addEventListener('change', () => {
+  formData.name = name.value;
+});
+
+emailInput.addEventListener('change', () => {
+  formData.email = emailInput.value;
+});
+
+message.addEventListener('change', () => {
+  formData.message = message.value;
+});
+
+let jsonData = JSON.stringify(formData);

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -5,7 +5,7 @@
 // create a single object for the data ✅
 // listen to change on input fields ✅
 // stringify that data ✅
-// set the object to local
+// set the object to local ✅
 // on loads of page
 // - if available:
 // - if local storage has data: put data into fiels
@@ -68,3 +68,5 @@ message.addEventListener('change', () => {
 });
 
 let jsonData = JSON.stringify(formData);
+
+availableStorage.setItem('contactFormData', jsonData)

--- a/javascript/localStorage.js
+++ b/javascript/localStorage.js
@@ -2,8 +2,8 @@
 // check local storage available ✅
 // - if available : create local storage object ✅
 // - if not: null ✅
-// create a single object for the data
-// listen to change on input fields
+// create a single object for the data ✅
+// listen to change on input fields ✅
 // stringify that data
 // set the object to local
 // on loads of page
@@ -14,6 +14,7 @@
 //! create a reset button that reset the input fields and delete data in local storage
 
 const contactForm = document.getElementById('contact-form');
+const {name, email: emailInput, message} = contactForm.elements
 
 function storageAvailable(type) {
   let storage;
@@ -49,5 +50,17 @@ if (storageAvailable('localStorage')) {
   availableStorage = window.localStorage;
 } else {
   // Too bad, no localStorage for us
-  return;
+ availableStorage = null;
 }
+
+let formData;
+
+name.addEventListener('change', (event) => {
+  console.log(event)
+})
+emailInput.addEventListener('change', (event) => {
+  console.log(event)
+})
+message.addEventListener('change', (event) => {
+  console.log(event)
+})

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -649,6 +649,34 @@ input {
   align-items: center;
 }
 
+#btn-reset {
+  height: 48px;
+  padding: 12px 16px;
+  font-weight: 500;
+  text-align: center;
+  letter-spacing: 0.03em;
+  background: #fff;
+  border-radius: 8px;
+  color: #6070ff;
+  border: none;
+  display: flex;
+  align-items: center;
+}
+
+#btn-reset:hover {
+  background: #6070ff;
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(64, 83, 252, 0.24);
+  border: 1px solid #fff;
+}
+
+#btn-reset:active {
+  background: #2230d2;
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(64, 83, 252, 0.24);
+  border: 1px solid #fff;
+}
+
 #btn-contact-form:hover {
   background: #6070ff;
   color: #fff;


### PR DESCRIPTION
In this PR we did the following:
- Agreed on steps for this PR
- Get the contact form element, verify localStorage supported and available, define availableStorage object
- Define the form data object and add event listeners on the input fields
- Get form data and stringify this in jsonData
- Set the contact form data object in local storage
- Retrieve data on page load and set the values on the inputs fields
- Fix persist data from all input fields
- Add the reset form button